### PR TITLE
Siphon energy

### DIFF
--- a/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
+++ b/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
@@ -150,7 +150,7 @@ MonoBehaviour:
   Path: Assets/FMOD/Build/Desktop/Master.bank
   Name: Master
   StudioPath: bank:/Master
-  lastModified: 638796603533138966
+  lastModified: 638804214866382579
   FileSizes:
   - Name: Desktop
     Value: 1074
@@ -170,7 +170,7 @@ MonoBehaviour:
   Path: Assets/FMOD/Build/Desktop/TEST_BANK.bank
   Name: TEST_BANK
   StudioPath: bank:/TEST_BANK
-  lastModified: 638796603533195659
+  lastModified: 638804214866438919
   FileSizes:
   - Name: Desktop
     Value: 22272
@@ -217,7 +217,7 @@ MonoBehaviour:
   Path: Assets/FMOD/Build/Desktop/BGM.bank
   Name: BGM
   StudioPath: bank:/BGM
-  lastModified: 638796603533118973
+  lastModified: 638804214866382579
   FileSizes:
   - Name: Desktop
     Value: 6849664
@@ -237,7 +237,7 @@ MonoBehaviour:
   Path: Assets/FMOD/Build/Desktop/Master.strings.bank
   Name: Master.strings
   StudioPath: bank:/Master.strings
-  lastModified: 638796603533148977
+  lastModified: 638804214866382579
   FileSizes:
   - Name: Desktop
     Value: 1444
@@ -279,7 +279,7 @@ MonoBehaviour:
   - {fileID: -2651969897897231559}
   StringsBanks:
   - {fileID: -1358000016533636209}
-  cacheTime: 638796603533195659
+  cacheTime: 638804214866438919
   cacheVersion: 131846
 --- !u!114 &1380586149865056763
 MonoBehaviour:
@@ -323,7 +323,7 @@ MonoBehaviour:
   Path: Assets/FMOD/Build/Desktop/SFX.bank
   Name: SFX
   StudioPath: bank:/SFX
-  lastModified: 638796603533180607
+  lastModified: 638804214866394800
   FileSizes:
   - Name: Desktop
     Value: 127968

--- a/Assets/Prefabs/Players/Warden.prefab
+++ b/Assets/Prefabs/Players/Warden.prefab
@@ -104,6 +104,7 @@ GameObject:
   - component: {fileID: 3046167562820563143}
   - component: {fileID: 6883891788245031158}
   - component: {fileID: 7937995718109404009}
+  - component: {fileID: 7562616938753922885}
   m_Layer: 7
   m_Name: Warden
   m_TagString: Player
@@ -461,6 +462,19 @@ MonoBehaviour:
   projectilePrefab: {fileID: 7603238177100266058, guid: 02ce3b291024fd946b9b2065d544b07e, type: 3}
   spawnPoint: {fileID: 7347747762842868080}
   prefab: {fileID: 5213519764763690752, guid: 5f9c5b65f2e8cab428a295d4d4d557fd, type: 3}
+--- !u!114 &7562616938753922885
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3424275855618714540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7d9b8ffdfcb8144cbfab172a264d4d9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  totalTime: 45
 --- !u!1 &8866154363906637985
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Players/Warden.prefab
+++ b/Assets/Prefabs/Players/Warden.prefab
@@ -105,6 +105,7 @@ GameObject:
   - component: {fileID: 6883891788245031158}
   - component: {fileID: 7937995718109404009}
   - component: {fileID: 7562616938753922885}
+  - component: {fileID: 5354700902847656464}
   m_Layer: 7
   m_Name: Warden
   m_TagString: Player
@@ -475,6 +476,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   totalTime: 45
+--- !u!114 &5354700902847656464
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3424275855618714540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ec81eba31dd9384eb685ddae8a0bf8d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8866154363906637985
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Scene Management/Hub Scene.unity
+++ b/Assets/Scenes/Scene Management/Hub Scene.unity
@@ -7343,6 +7343,10 @@ PrefabInstance:
       propertyPath: gathererRadiusCircle
       value: 
       objectReference: {fileID: 1330570183}
+    - target: {fileID: 3046167562820563143, guid: 9d03b969a4374bd4f84e8fbabded0f21, type: 3}
+      propertyPath: <NumHitsRequired>k__BackingField
+      value: 100
+      objectReference: {fileID: 0}
     - target: {fileID: 3424275855618714540, guid: 9d03b969a4374bd4f84e8fbabded0f21, type: 3}
       propertyPath: m_Name
       value: Warden
@@ -7402,6 +7406,10 @@ PrefabInstance:
     - target: {fileID: 7479631434780333628, guid: 9d03b969a4374bd4f84e8fbabded0f21, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7562616938753922885, guid: 9d03b969a4374bd4f84e8fbabded0f21, type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7834940100660095115, guid: 9d03b969a4374bd4f84e8fbabded0f21, type: 3}
       propertyPath: m_PresetInfoIsWorld

--- a/Assets/Scenes/Scene Management/Hub Scene.unity
+++ b/Assets/Scenes/Scene Management/Hub Scene.unity
@@ -5911,16 +5911,16 @@ MonoBehaviour:
   abilityImage: {fileID: 1243710221}
   abilityButton: {fileID: 1243710220}
   abilitySelectManager: {fileID: 45010631}
-  abilityID: 
+  abilityID: DeathDefy
   normalSprite: {fileID: 21300000, guid: f0e27b584602e6640a2eff97fd6a1f74, type: 3}
   hoverSprite: {fileID: 21300000, guid: 6fe8e3bd580485147a5c03ac9233edb8, type: 3}
   selectSprite: {fileID: 21300000, guid: cfd2e26cea4ff784eaeb433ead54bc3e, type: 3}
   lockedSprite: {fileID: 21300000, guid: 2acf2361e3accc648be09de2d38ca0da, type: 3}
-  abilityText: gives you 20/20 vison
+  abilityText: '"HEROES NEVER DIE"'
   abilityName: Resurrection Regalia
   isWarden: 1
   isActive: 0
-  isLocked: 1
+  isLocked: 0
 --- !u!114 &1243710220
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9849,7 +9849,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6263869502043627533, guid: 3662ccf3678e8a946898d972d7d1a732, type: 3}
       propertyPath: equipedAbilityName
-      value: 2
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7019890448366990970, guid: 3662ccf3678e8a946898d972d7d1a732, type: 3}
       propertyPath: questDisplay

--- a/Assets/Scripts/Abilities/GathererAbilities/SiphonEnergy.cs
+++ b/Assets/Scripts/Abilities/GathererAbilities/SiphonEnergy.cs
@@ -12,6 +12,9 @@ public class SiphonEnergy : PassiveAbilities
 
     //helps keep code clean
     private WardenAbilityManager abilityManager = WardenAbilityManager.Instance;
+
+    //change much % of the total you gain
+    public float percent;
     void InitSingleton() { if (Instance && Instance != this) Destroy(gameObject); else Instance = this; }
     void Awake()
     {
@@ -28,7 +31,7 @@ public class SiphonEnergy : PassiveAbilities
 
     //add energy method
     public void addEnergy() {
-        abilityManager.equipedAbility.Charge = abilityManager.equipedAbility.Charge + (0.03f * abilityManager.equipedAbility.numHitsRequired);
+        abilityManager.equipedAbility.Charge = abilityManager.equipedAbility.Charge + (percent * abilityManager.equipedAbility.numHitsRequired);
         if (abilityManager.equipedAbility.Charge > abilityManager.equipedAbility.numHitsRequired) {
             abilityManager.equipedAbility.Charge = abilityManager.equipedAbility.numHitsRequired;
         }

--- a/Assets/Scripts/Abilities/GathererAbilities/SiphonEnergy.cs
+++ b/Assets/Scripts/Abilities/GathererAbilities/SiphonEnergy.cs
@@ -1,14 +1,17 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Resources;
 using UnityEngine;
 
 public class SiphonEnergy : PassiveAbilities
 {
     // Start is called before the first frame update
-    public override string abilityName => "Siphon Energy";
+    public override string abilityName => "SiphonEnergy";
     public static SiphonEnergy Instance { get; private set; }
 
-    public bool moreEnergy = true;
+    //helps keep code clean
+    private WardenAbilityManager abilityManager = WardenAbilityManager.Instance;
     void InitSingleton() { if (Instance && Instance != this) Destroy(gameObject); else Instance = this; }
     void Awake()
     {
@@ -16,9 +19,19 @@ public class SiphonEnergy : PassiveAbilities
     }
     public override void passiveUpdate()
     {
-        //All this does is turn this ability on or off
-        //Everytime an enemy dies, calls a method in the
-        if (moreEnergy) { moreEnergy = false; }
-        else { moreEnergy = true; }
+        //if siphonTimes is greater than 0 then add 3% of total energy
+        if (abilityManager.siphonTimes > 0) {
+            addEnergy();
+            abilityManager.siphonTimes--;
+        }
     }
+
+    //add energy method
+    public void addEnergy() {
+        abilityManager.equipedAbility.Charge = abilityManager.equipedAbility.Charge + (0.03f * abilityManager.equipedAbility.numHitsRequired);
+        if (abilityManager.equipedAbility.Charge > abilityManager.equipedAbility.numHitsRequired) {
+            abilityManager.equipedAbility.Charge = abilityManager.equipedAbility.numHitsRequired;
+        }
+    }
+
 }

--- a/Assets/Scripts/Abilities/WardenAbilities/WardenAbilityManager.cs
+++ b/Assets/Scripts/Abilities/WardenAbilities/WardenAbilityManager.cs
@@ -1,3 +1,4 @@
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
@@ -14,8 +15,11 @@ public class WardenAbilityManager : MonoBehaviour
     public WardenBaseAbilities equipedAbility;
     [SerializeField] Abilities equipedAbilityName;
     public PassiveAbilities passiveAbility;
-    [SerializeField] string passiveAbilityName;
+    [SerializeField] public string passiveAbilityName;
     [SerializeField] private Controls controls;
+
+    //amount of times you kill an enemy for energy
+    public float siphonTimes;
 
     public static WardenAbilityManager Instance { get; private set; }
     public static Controls Controls {get => Instance.controls;}
@@ -48,6 +52,7 @@ public class WardenAbilityManager : MonoBehaviour
             equipedAbility = WardenDevastationBeam.Instance;
             equipedAbilityName = Abilities.DevastationBeam;
         }
+        EquipPassive("SiphonEnergy");
     }
     void OnActivateAbility(InputAction.CallbackContext context)
     {
@@ -90,6 +95,9 @@ public class WardenAbilityManager : MonoBehaviour
             {
                 case "DeathDefy":
                     passiveAbility = AbilityDeathDefy.Instance;
+                    break;
+                case "SiphonEnergy":
+                    passiveAbility = SiphonEnergy.Instance;
                     break;
                 default:
                     print("failed to swap to: " + passiveAbilityName);
@@ -135,6 +143,11 @@ public class WardenAbilityManager : MonoBehaviour
             {
                 case "DeathDefy":
                     passiveAbility = AbilityDeathDefy.Instance;
+                    passiveAbilityName = abilityID;
+                    print("swap to: " + abilityID);
+                    break;
+                case "SiphonEnergy":
+                    passiveAbility = SiphonEnergy.Instance;
                     passiveAbilityName = abilityID;
                     print("swap to: " + abilityID);
                     break;

--- a/Assets/Scripts/Abilities/WardenAbilities/WardenBaseAbilities.cs
+++ b/Assets/Scripts/Abilities/WardenAbilities/WardenBaseAbilities.cs
@@ -39,5 +39,6 @@ public abstract class WardenBaseAbilities : MonoBehaviour
     public abstract string abilityName { get; }
     public abstract int numHitsRequired { get; }
     public abstract float duration { get; }
+    public abstract float Charge { get; set; }
 
 }

--- a/Assets/Scripts/Abilities/WardenAbilities/WardenDevastationBeam.cs
+++ b/Assets/Scripts/Abilities/WardenAbilities/WardenDevastationBeam.cs
@@ -5,7 +5,6 @@ public class WardenDevastationBeam : WardenBaseAbilities
 {
     [field: Header("Charge")]
     [field: SerializeField] public int NumHitsRequired {  get; private set; }
-    public int Charge { get; private set; } = 0;
 
     [Header("Damage")]
     [SerializeField] float damagePerTick;
@@ -25,6 +24,14 @@ public class WardenDevastationBeam : WardenBaseAbilities
     public override string abilityName => "DevastationBeam";
     public override int numHitsRequired => NumHitsRequired;
     public override float duration => abilityDuration;
+    //changed charge to a float so I can add 3% of the total charge for each kill
+    //also added Charge to WardenBaseAbilities so I can reference charge when saving the instance of the passive ability in a passiveabilities variable
+    [SerializeField]private float charge;
+    public override float Charge
+    {
+        get => charge;
+        set => charge = value;
+    }
 
     public static WardenDevastationBeam Instance { get; private set; } void InitSingleton() { if (Instance && Instance != this) Destroy(gameObject); else Instance = this; }
 
@@ -35,7 +42,7 @@ public class WardenDevastationBeam : WardenBaseAbilities
     void GainCharge()
     {
         Charge++;
-        if (Charge == NumHitsRequired) { AudioManager.Instance.PlayOneShot(FMODEvents.Instance.abilityReady, this.transform.position); }
+        if (Charge >= NumHitsRequired) { AudioManager.Instance.PlayOneShot(FMODEvents.Instance.abilityReady, this.transform.position); }
         if (Charge > NumHitsRequired) Charge = NumHitsRequired;
     }
 
@@ -44,6 +51,6 @@ public class WardenDevastationBeam : WardenBaseAbilities
         if (Charge < NumHitsRequired) return;
         DevastationBeam db = Instantiate(prefab, spawnPoint).GetComponent<DevastationBeam>();
         db.Activate(damagePerTick, damageTickDuration, knockbackForce, knockbackTickDuration, abilityDuration);
-        Charge = 0;
+        Charge = 0f;
     }
 }

--- a/Assets/Scripts/Abilities/WardenAbilities/WardenGourdForge.cs
+++ b/Assets/Scripts/Abilities/WardenAbilities/WardenGourdForge.cs
@@ -4,7 +4,6 @@ public class WardenGourdForge : WardenBaseAbilities
 {
     [field: Header("Charge")]
     [field: SerializeField] public int NumHitsRequired { get; private set; }
-    public int Charge { get; private set; } = 0;
 
     [Header("Damage")]
     [SerializeField] float damagePerTick;
@@ -22,6 +21,14 @@ public class WardenGourdForge : WardenBaseAbilities
     public override string abilityName => "GourdForge";
     public override int numHitsRequired => NumHitsRequired;
     public override float duration => abilityDuration;
+    //changed charge to a float so I can add 3% of the total charge for each kill
+    //also added Charge to WardenBaseAbilities so I can reference charge when saving the instance of the passive ability in a passiveabilities variable
+    [SerializeField] private float charge;
+    public override float Charge
+    {
+        get => charge;
+        set => charge = value;
+    }
 
     public static WardenGourdForge Instance { get; private set; }
     void InitSingleton() { if (Instance && Instance != this) Destroy(gameObject); else Instance = this; }
@@ -32,7 +39,7 @@ public class WardenGourdForge : WardenBaseAbilities
     void GainCharge()
     {
         Charge++;
-        if (Charge == NumHitsRequired) { AudioManager.Instance.PlayOneShot(FMODEvents.Instance.abilityReady, this.transform.position); }
+        if (Charge >= NumHitsRequired) { AudioManager.Instance.PlayOneShot(FMODEvents.Instance.abilityReady, this.transform.position); }
         if (Charge > NumHitsRequired) Charge = NumHitsRequired;
     }
 
@@ -41,6 +48,6 @@ public class WardenGourdForge : WardenBaseAbilities
         if (Charge < NumHitsRequired) return;
         GourdForge gourdForge = Instantiate(prefab, spawnPoint).GetComponent<GourdForge>();
         gourdForge.Activate(damagePerTick, damageTickDuration, size, abilityDuration);
-        Charge = 0;
+        Charge = 0f;
     }
 }

--- a/Assets/Scripts/Abilities/WardenAbilities/WardenSpellBurst.cs
+++ b/Assets/Scripts/Abilities/WardenAbilities/WardenSpellBurst.cs
@@ -5,7 +5,6 @@ public class WardenSpellBurst : WardenBaseAbilities
 {
     [field: Header("Charge")]
     [field: SerializeField] public int NumHitsRequired { get; private set; }
-    public int Charge { get; private set; } = 0;
 
     [Header("Projectile Stats")]
     public float projectileDamage;
@@ -28,7 +27,14 @@ public class WardenSpellBurst : WardenBaseAbilities
     public override string abilityName => "SpellBurst";
     public override int numHitsRequired => NumHitsRequired;
     public override float duration => abilityDuration;
-
+    //changed charge to a float so I can add 3% of the total charge for each kill
+    //also added Charge to WardenBaseAbilities so I can reference charge when saving the instance of the passive ability in a passiveabilities variable
+    [SerializeField] private float charge;
+    public override float Charge
+    {
+        get => charge;
+        set => charge = value;
+    }
     public static WardenSpellBurst Instance { get; private set; }
     void InitSingleton() { if (Instance && Instance != this) Destroy(gameObject); else Instance = this; }
     void Awake() { InitSingleton(); }
@@ -38,7 +44,7 @@ public class WardenSpellBurst : WardenBaseAbilities
     void GainCharge()
     {
         Charge++;
-        if (Charge == NumHitsRequired) { AudioManager.Instance.PlayOneShot(FMODEvents.Instance.abilityReady, this.transform.position); }
+        if (Charge >= NumHitsRequired) { AudioManager.Instance.PlayOneShot(FMODEvents.Instance.abilityReady, this.transform.position); }
         if (Charge > NumHitsRequired) Charge = NumHitsRequired;
     }
 
@@ -47,6 +53,6 @@ public class WardenSpellBurst : WardenBaseAbilities
         if (Charge < NumHitsRequired) return;
         SpellBurst spellBurst = Instantiate(prefab, transform.position, Quaternion.identity).GetComponent<SpellBurst>();
         spellBurst.Activate(projectileDamage, projectileSpeed, projectileRotationForce, projectileLifetime, timeBetweenProjectile, projectilePerBurst, abilityDuration);
-        Charge = 0;
+        Charge = 0f;
     }
 }

--- a/Assets/Scripts/Enemy/BaseEnemy.cs
+++ b/Assets/Scripts/Enemy/BaseEnemy.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections;
+using UnityEditor.Profiling.Memory.Experimental;
 using UnityEngine;
 using UnityEngine.AI;
 
@@ -17,7 +19,7 @@ public class BaseEnemyClass : MonoBehaviour
     public NavMeshAgent agent;
 
     public Rigidbody2D rb;
-
+    SiphonEnergy siphon;
     public void Spawn(Vector3 position)
     {
         Instantiate(gameObject, position, Quaternion.identity);
@@ -35,6 +37,11 @@ public class BaseEnemyClass : MonoBehaviour
     public virtual void Die()
     {
         EnemySpawner.currentEnemyCount--;
+        //if siphon energy is equipped then add to siphone times
+        if (WardenAbilityManager.Instance.passiveAbilityName == "SiphonEnergy")
+        {
+            WardenAbilityManager.Instance.siphonTimes++;
+        }
         Destroy(gameObject);
     }
 

--- a/Assets/Scripts/PlayerController/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerController/PlayerMovement.cs
@@ -14,7 +14,7 @@ public class PlayerMovement : MonoBehaviour
 
 	void OnMove(InputValue iv)  // Called by the Player Input component
 	{
-		print("blah");
+		//print("blah");
 		moveDirection = iv.Get<Vector2>() * (canMove ? 1 : 0);
 	}
 


### PR DESCRIPTION
Edited the Base Enemy die function to allow for energy siphon. Edited WardenBaseAbilities and all abilities to include a float charge variable. Also added the siphon energy to the cases for choosing passive ability on the main screen and keeping the ability when switching scenes. You can change the amount of charge back you get in the inspector from (0-1) 0.5 being half of your total charge comes back.